### PR TITLE
handle deletion

### DIFF
--- a/pkg/cluster/controller.go
+++ b/pkg/cluster/controller.go
@@ -89,7 +89,7 @@ func (c *clusterController) sync(ctx context.Context, syncCtx factory.SyncContex
 	if !managedCluster.DeletionTimestamp.IsZero() {
 		// the managed cluster is deleting, we should not re-apply the manifestwork
 		// wait for managedcluster-import-controller to clean up the manifestwork
-		return nil
+		return removePostponeDeleteAnnotationForSubManifestwork(ctx, c.workclient, c.workLister, managedClusterName)
 	}
 
 	subscription, err := ApplySubManifestWorks(ctx, c.workclient, c.workLister, managedClusterName)

--- a/pkg/cluster/controller.go
+++ b/pkg/cluster/controller.go
@@ -69,8 +69,8 @@ func NewHubClusterController(
 					return false
 				}
 				// only enqueue when the hoh=enabled managed cluster is changed
-				if accessor.GetName() == accessor.GetNamespace()+"-"+HOH_HUB_CLUSTER_SUBSCRIPTION ||
-					accessor.GetName() == accessor.GetNamespace()+"-"+HOH_HUB_CLUSTER_MCH {
+				if accessor.GetName() == accessor.GetNamespace()+"-"+hohHubClusterSubscription ||
+					accessor.GetName() == accessor.GetNamespace()+"-"+hohHubClusterMCH {
 					return true
 				}
 				return false
@@ -82,15 +82,16 @@ func NewHubClusterController(
 func (c *clusterController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
 	managedClusterName := syncCtx.QueueKey()
 	klog.V(2).Infof("Reconciling for %s", managedClusterName)
-	// managedCluster, err := c.clusterLister.Get(managedClusterName)
-	// if errors.IsNotFound(err) {
-	// 	// Spoke cluster not found, could have been deleted, delete manifestwork.
-	// 	// TODO: delete manifestwork
-	// 	return nil
-	// }
-	// if err != nil {
-	// 	return err
-	// }
+	managedCluster, err := c.clusterLister.Get(managedClusterName)
+	if err != nil {
+		return err
+	}
+	if !managedCluster.DeletionTimestamp.IsZero() {
+		// the managed cluster is deleting, we should not re-apply the manifestwork
+		// wait for managedcluster-import-controller to clean up the manifestwork
+		return nil
+	}
+
 	subscription, err := ApplySubManifestWorks(ctx, c.workclient, c.workLister, managedClusterName)
 	if err != nil {
 		return err

--- a/pkg/cluster/manifestwork.go
+++ b/pkg/cluster/manifestwork.go
@@ -20,8 +20,8 @@ import (
 )
 
 const (
-	HOH_HUB_CLUSTER_SUBSCRIPTION = "hoh-hub-cluster-subscription"
-	HOH_HUB_CLUSTER_MCH          = "hoh-hub-cluster-mch"
+	hohHubClusterSubscription = "hoh-hub-cluster-subscription"
+	hohHubClusterMCH          = "hoh-hub-cluster-mch"
 )
 
 func createSubManifestwork(namespace string, p *packagemanifest.PackageManifest) *workv1.ManifestWork {
@@ -30,7 +30,7 @@ func createSubManifestwork(namespace string, p *packagemanifest.PackageManifest)
 	}
 	return &workv1.ManifestWork{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      namespace + "-" + HOH_HUB_CLUSTER_SUBSCRIPTION,
+			Name:      namespace + "-" + hohHubClusterSubscription,
 			Namespace: namespace,
 			Labels: map[string]string{
 				"hub-of-hubs.open-cluster-management.io/managed-by": "hoh",
@@ -180,7 +180,7 @@ func createMCHManifestwork(namespace, userDefinedMCH string) (*workv1.ManifestWo
 	}
 	return &workv1.ManifestWork{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      namespace + "-" + HOH_HUB_CLUSTER_MCH,
+			Name:      namespace + "-" + hohHubClusterMCH,
 			Namespace: namespace,
 			Labels: map[string]string{
 				"hub-of-hubs.open-cluster-management.io/managed-by": "hoh",
@@ -291,7 +291,7 @@ func ApplySubManifestWorks(ctx context.Context, workclient workclientv1.WorkV1In
 		return nil, nil
 	}
 
-	subscription, err := workLister.ManifestWorks(managedClusterName).Get(managedClusterName + "-" + HOH_HUB_CLUSTER_SUBSCRIPTION)
+	subscription, err := workLister.ManifestWorks(managedClusterName).Get(managedClusterName + "-" + hohHubClusterSubscription)
 	if errors.IsNotFound(err) {
 		klog.V(2).Infof("creating subscription manifestwork in %s namespace", managedClusterName)
 		_, err := workclient.ManifestWorks(managedClusterName).
@@ -358,7 +358,7 @@ func ApplyMCHManifestWorks(ctx context.Context, workclient workclientv1.WorkV1In
 	if err != nil {
 		return err
 	}
-	mch, err := workLister.ManifestWorks(managedClusterName).Get(managedClusterName + "-" + HOH_HUB_CLUSTER_MCH)
+	mch, err := workLister.ManifestWorks(managedClusterName).Get(managedClusterName + "-" + hohHubClusterMCH)
 	if errors.IsNotFound(err) {
 		klog.V(2).Infof("creating mch manifestwork in %s namespace", managedClusterName)
 		_, err := workclient.ManifestWorks(managedClusterName).

--- a/pkg/cluster/manifestwork_test.go
+++ b/pkg/cluster/manifestwork_test.go
@@ -18,8 +18,8 @@ func TestCreateMCHManifestwork(t *testing.T) {
 			"imagePullSecret": "multiclusterhub-operator-pull-secret"
 		}
 	}`)
-	if mch.GetName() != "test-"+HOH_HUB_CLUSTER_MCH {
-		t.Fatalf("failed to find the %s manifestwork", "test-"+HOH_HUB_CLUSTER_MCH)
+	if mch.GetName() != "test-"+hohHubClusterMCH {
+		t.Fatalf("failed to find the %s manifestwork", "test-"+hohHubClusterMCH)
 	}
 	mchByte, err := json.Marshal(mch)
 	if err != nil {


### PR DESCRIPTION
add this annotation `open-cluster-management/postpone-delete` to subscription manifestwork so that we can leverage import-controller to clean up the mch manifestwork firstly. and then hub cluster controller removes this annotation to enable cleaning up by the import controller.