### PR TITLE
fix manifestwork compare logic.

### DIFF
--- a/pkg/cluster/manifestwork.go
+++ b/pkg/cluster/manifestwork.go
@@ -9,6 +9,7 @@ import (
 
 	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -418,18 +419,47 @@ func createMCHManifestwork(namespace, userDefinedMCH string, imagePullSecret *co
 }
 
 func EnsureManifestWork(existing, desired *workv1.ManifestWork) (bool, error) {
-	// compare the manifests
-	existingBytes, err := json.Marshal(existing.Spec)
-	if err != nil {
-		return false, err
-	}
-	desiredBytes, err := json.Marshal(desired.Spec)
-	if err != nil {
-		return false, err
-	}
-	if string(existingBytes) != string(desiredBytes) {
+	if !equality.Semantic.DeepDerivative(existing.Spec.DeleteOption, desired.Spec.DeleteOption) {
 		return true, nil
 	}
+
+	if !equality.Semantic.DeepDerivative(existing.Spec.ManifestConfigs, desired.Spec.ManifestConfigs) {
+		return true, nil
+	}
+
+	if len(existing.Spec.Workload.Manifests) != len(desired.Spec.Workload.Manifests) {
+		return true, nil
+	}
+
+	for i, m := range existing.Spec.Workload.Manifests {
+		var existingObj, desiredObj interface{}
+		if len(m.RawExtension.Raw) > 0 {
+			if err := json.Unmarshal(m.RawExtension.Raw, &existingObj); err != nil {
+				return false, err
+			}
+		} else {
+			existingObj = m.RawExtension.Object
+		}
+
+		if len(desired.Spec.Workload.Manifests[i].RawExtension.Raw) > 0 {
+			if err := json.Unmarshal(desired.Spec.Workload.Manifests[i].RawExtension.Raw, &desiredObj); err != nil {
+				return false, err
+			}
+		} else {
+			desiredObjBytes, err := json.Marshal(desired.Spec.Workload.Manifests[i].RawExtension.Object)
+			if err != nil {
+				return false, err
+			}
+			if err := json.Unmarshal(desiredObjBytes, &desiredObj); err != nil {
+				return false, err
+			}
+		}
+
+		if !equality.Semantic.DeepDerivative(existingObj, desiredObj) {
+			return true, nil
+		}
+	}
+
 	return false, nil
 }
 

--- a/pkg/cluster/manifestwork_test.go
+++ b/pkg/cluster/manifestwork_test.go
@@ -4,7 +4,37 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	workv1 "open-cluster-management.io/api/work/v1"
 )
+
+var testConfigMapStr = `{
+	"apiVersion": "v1",
+	"kind": "ConfigMap",
+	"metadata": {
+	  "name": "foo",
+	  "namespace": "test"
+	},
+	"data": {
+	  "key1": "value1",
+	  "key2": "value2"
+	}
+  }`
+
+var testConfigMapObj = &corev1.ConfigMap{
+	TypeMeta: metav1.TypeMeta{
+		Kind:       "ConfigMap",
+		APIVersion: "v1",
+	},
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "foo",
+		Namespace: "test",
+	},
+	Data: map[string]string{"key1": "value1", "key2": "value2"},
+}
 
 func TestCreateMCHManifestwork(t *testing.T) {
 	mch, _ := createMCHManifestwork("test", `{
@@ -27,5 +57,232 @@ func TestCreateMCHManifestwork(t *testing.T) {
 	}
 	if !strings.Contains(string(mchByte), "disableHubSelfManagement") {
 		t.Fatalf("failed to find disableHubSelfManagement")
+	}
+}
+
+func TestEnsureManifestWork(t *testing.T) {
+	tests := []struct {
+		desc                 string
+		existingManifestwork *workv1.ManifestWork
+		desiredManifestwork  *workv1.ManifestWork
+		wantChanged          bool
+		wantErr              string
+	}{
+		{
+			desc: "DifferentDeletePropagationPolicy",
+			existingManifestwork: &workv1.ManifestWork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+				},
+				Spec: workv1.ManifestWorkSpec{
+					DeleteOption: &workv1.DeleteOption{
+						PropagationPolicy: workv1.DeletePropagationPolicyTypeOrphan,
+					},
+				},
+			},
+			desiredManifestwork: &workv1.ManifestWork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+				},
+				Spec: workv1.ManifestWorkSpec{
+					DeleteOption: &workv1.DeleteOption{
+						PropagationPolicy: workv1.DeletePropagationPolicyTypeForeground,
+					},
+				},
+			},
+			wantChanged: true,
+			wantErr:     "",
+		},
+		{
+			desc: "DifferentManifestConfigs",
+			existingManifestwork: &workv1.ManifestWork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+				},
+				Spec: workv1.ManifestWorkSpec{
+					ManifestConfigs: []workv1.ManifestConfigOption{
+						{
+							ResourceIdentifier: workv1.ResourceIdentifier{
+								Group:     "",
+								Resource:  "services",
+								Name:      "foo",
+								Namespace: "test",
+							},
+							FeedbackRules: []workv1.FeedbackRule{
+								{
+									Type: workv1.JSONPathsType,
+									JsonPaths: []workv1.JsonPath{
+										{
+											Name: "clusterIP",
+											Path: ".spec.clusterIP",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			desiredManifestwork: &workv1.ManifestWork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+				},
+				Spec: workv1.ManifestWorkSpec{
+					ManifestConfigs: []workv1.ManifestConfigOption{
+						{
+							ResourceIdentifier: workv1.ResourceIdentifier{
+								Group:     "",
+								Resource:  "services",
+								Name:      "bar",
+								Namespace: "test",
+							},
+							FeedbackRules: []workv1.FeedbackRule{
+								{
+									Type: workv1.JSONPathsType,
+									JsonPaths: []workv1.JsonPath{
+										{
+											Name: "clusterIP",
+											Path: ".spec.clusterIP",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantChanged: true,
+			wantErr:     "",
+		},
+		{
+			desc: "DifferentManifestsNumber",
+			existingManifestwork: &workv1.ManifestWork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+				},
+				Spec: workv1.ManifestWorkSpec{
+					Workload: workv1.ManifestsTemplate{
+						Manifests: []workv1.Manifest{
+							{RawExtension: runtime.RawExtension{
+								Raw: []byte(testConfigMapStr),
+							}},
+						},
+					},
+				},
+			},
+			desiredManifestwork: &workv1.ManifestWork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+				},
+				Spec: workv1.ManifestWorkSpec{
+					Workload: workv1.ManifestsTemplate{
+						Manifests: []workv1.Manifest{
+							{RawExtension: runtime.RawExtension{
+								Raw: []byte(testConfigMapStr),
+							}},
+							{RawExtension: runtime.RawExtension{
+								Raw: []byte(testConfigMapStr),
+							}},
+						},
+					},
+				},
+			},
+			wantChanged: true,
+			wantErr:     "",
+		},
+		{
+			desc: "SameManifestwork",
+			existingManifestwork: &workv1.ManifestWork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+				},
+				Spec: workv1.ManifestWorkSpec{
+					Workload: workv1.ManifestsTemplate{
+						Manifests: []workv1.Manifest{
+							{RawExtension: runtime.RawExtension{
+								Raw: []byte(testConfigMapStr),
+							}},
+						},
+					},
+				},
+			},
+			desiredManifestwork: &workv1.ManifestWork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+				},
+				Spec: workv1.ManifestWorkSpec{
+					Workload: workv1.ManifestsTemplate{
+						Manifests: []workv1.Manifest{
+							{RawExtension: runtime.RawExtension{
+								Raw: []byte(testConfigMapStr),
+							}},
+						},
+					},
+				},
+			},
+			wantChanged: false,
+			wantErr:     "",
+		},
+		{
+			desc: "SameManifestworkWithDifferentManifestFormat",
+			existingManifestwork: &workv1.ManifestWork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+				},
+				Spec: workv1.ManifestWorkSpec{
+					Workload: workv1.ManifestsTemplate{
+						Manifests: []workv1.Manifest{
+							{RawExtension: runtime.RawExtension{
+								Raw: []byte(testConfigMapStr),
+							}},
+						},
+					},
+				},
+			},
+			desiredManifestwork: &workv1.ManifestWork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+				},
+				Spec: workv1.ManifestWorkSpec{
+					Workload: workv1.ManifestsTemplate{
+						Manifests: []workv1.Manifest{
+							{RawExtension: runtime.RawExtension{
+								Object: testConfigMapObj,
+							}},
+						},
+					},
+				},
+			},
+			wantChanged: false,
+			wantErr:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			gotChanged, gotErr := EnsureManifestWork(tt.existingManifestwork, tt.desiredManifestwork)
+			if gotErr != nil {
+				if gotErr.Error() != tt.wantErr {
+					t.Fatalf("EnsureManifestWork(%s): gotErr:%v, wanrErr:%v", tt.desc, gotErr, tt.wantErr)
+				}
+			} else {
+				if tt.wantErr != "" {
+					t.Fatalf("EnsureManifestWork(%s): gotErr:%v, wanrErr:%v", tt.desc, gotErr, tt.wantErr)
+				}
+			}
+			if gotChanged != tt.wantChanged {
+				t.Fatalf("EnsureManifestWork(%s): gotChanged:%v, wantChanged:%v", tt.desc, gotChanged, tt.wantChanged)
+			}
+		})
 	}
 }


### PR DESCRIPTION
The old manifestwork compare logic will always return true, which will make the controller keep updating the manifestwork, although no change.

Signed-off-by: morvencao <lcao@redhat.com>