### PR TITLE
fix permission issue for hub components in hypershift case.

### DIFF
--- a/pkg/cluster/manifests/hypershift/management/04-policy-addon-controller.yaml
+++ b/pkg/cluster/manifests/hypershift/management/04-policy-addon-controller.yaml
@@ -51,7 +51,7 @@ metadata:
   creationTimestamp: null
   labels:
     app: governance-policy-addon-controller
-  name: policy-addon-ctrl-manager-role
+  name: policy-addon-ctrl-manager-role-{{.HostedClusterName}}
 rules:
 - apiGroups:
   - addon.open-cluster-management.io
@@ -289,11 +289,11 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app: governance-policy-addon-controller
-  name: policy-addon-ctrl-manager-rolebinding
+  name: policy-addon-ctrl-manager-rolebinding-{{.HostedClusterName}}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: policy-addon-ctrl-manager-role
+  name: policy-addon-ctrl-manager-role-{{.HostedClusterName}}
 subjects:
 - kind: ServiceAccount
   name: policy-addon-ctrl-controller-manager

--- a/pkg/cluster/manifests/hypershift/management/05-policy-propagator.yaml
+++ b/pkg/cluster/manifests/hypershift/management/05-policy-propagator.yaml
@@ -45,7 +45,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: governance-policy-propagator
+  name: governance-policy-propagator-{{.HostedClusterName}}
 rules:
 - apiGroups:
   - apps.open-cluster-management.io
@@ -231,11 +231,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: governance-policy-propagator-global
+  name: governance-policy-propagator-{{.HostedClusterName}}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: governance-policy-propagator
+  name: governance-policy-propagator-{{.HostedClusterName}}
 subjects:
 - kind: ServiceAccount
   name: governance-policy-propagator

--- a/pkg/cluster/manifests/hypershift/management/06-multicluster-operators-rbac.yaml
+++ b/pkg/cluster/manifests/hypershift/management/06-multicluster-operators-rbac.yaml
@@ -8,25 +8,31 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: multicluster-operators
+  name: multicluster-operators-{{.HostedClusterName}}
 rules:
 - apiGroups:
-  - '*'
+  - ''
   resources:
+  - 'services'
+  verbs:
   - '*'
+- apiGroups:
+  - 'apps'
+  resources:
+  - 'deployments'
   verbs:
   - '*'
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: multicluster-operators
+  name: multicluster-operators-{{.HostedClusterName}}
 subjects:
 - kind: ServiceAccount
   name: multicluster-operators
   namespace: {{.HostedClusterName}}
 roleRef:
   kind: ClusterRole
-  name: multicluster-operators
+  name: multicluster-operators-{{.HostedClusterName}}
   apiGroup: rbac.authorization.k8s.io
 ---


### PR DESCRIPTION
The global RBAC was overrided when there are multiple hypershift hosted clusters created.

Signed-off-by: morvencao <lcao@redhat.com>